### PR TITLE
Add Demo Application without TEE and some Documentation

### DIFF
--- a/iexec-apps/demo-without-tee/Dockerfile
+++ b/iexec-apps/demo-without-tee/Dockerfile
@@ -1,0 +1,6 @@
+
+FROM python:3.12.0a1-alpine3.16
+### install python dependencies if you have some
+
+COPY ./src /app
+ENTRYPOINT ["python3", "/app/app.py"]

--- a/iexec-apps/demo-without-tee/README.md
+++ b/iexec-apps/demo-without-tee/README.md
@@ -1,0 +1,87 @@
+# IExec Demo App (non-TEE)
+
+This is a simple demo application that checks if the income of a tenant is
+three times as high as the rent. It does not run in a TEE and it simply
+takes the RENT and MONTHLY_INCOME as arguments.
+
+The app is already deployed to the iExec marketplace and can be run using
+```bash
+iexec app run 0x5e4017Bd35CbA7827e0Fa193F4B9F4f158FA254E --args "400 1300" --watch --chain bellecour
+```
+and the results can be retreived with
+```bash
+iexec task show <taskid> --download my-app-result --chain bellecour  \
+    && unzip my-app-result.zip -d my-app-result
+```
+
+## Adjust and Redeploy
+
+In order to deploy this app, follow these steps:
+
+Install the iExec SDK cli (requires 
+[![npm version](https://img.shields.io/badge/nodejs-%3E=14.0.0-brightgreen.svg)](https://nodejs.org/en/)):
+```bash
+npm i -g iexec
+```
+
+Create a new wallet file
+```bash
+iexec wallet create
+```
+
+Initialize iExec project with
+```bash
+iexec init --skip-wallet
+```
+
+Initialize remote storage for output files
+```bash
+iexec storage init --chain bellecour
+```
+
+If you made some changes to the application in [app](src/app.py) or the [Dockerfile](Dockerfile),
+you need to rebuild it and push it to Dockerhub
+```bash
+docker build . --tag <app-name>
+
+docker login
+docker tag <app-name> <dockerusername>/<app-name>:1.0.0
+docker push <dockerusername>/<app-name>:1.0.0
+```
+
+If you want to test the app locally before pushing it, use the [run](run.sh) script.
+
+## Deploy the app on iExec
+Adjust the file [iexec](iexec.json).
+* Enter your wallet address
+* Set the app name
+* As multiaddr, set the URI to the docker image on dockerhub
+* Replace the app checksum (it is the sha256 digest of the image on dockerhub)
+
+```bash
+iexec app deploy --chain bellecour
+iexec app show --chain bellecour
+```
+
+## Run the app on iExec
+```bash
+iexec app run --args "400 1300" --watch --chain bellecour
+
+## download the result
+iexec task show <taskid> --download my-app-result --chain bellecour  \
+    && unzip my-app-result.zip -d my-app-result
+```
+Debug the app using
+```bash
+iexec task debug <taskid> --logs --chain bellecour
+```
+
+## Publish the app to the iExec marketplace
+```bash
+iexec app publish --chain bellecour
+```
+Now, the app is publicly available and can be run using the CLI commands
+```bash
+iexec app run <app-address> --args "400 1300" --watch --chain bellecour
+```
+The result can be downloaded the same way as described above.

--- a/iexec-apps/demo-without-tee/chain.json
+++ b/iexec-apps/demo-without-tee/chain.json
@@ -1,0 +1,11 @@
+{
+  "default": "bellecour",
+  "chains": {
+    "goerli": {},
+    "viviani": {},
+    "mainnet": {},
+    "bellecour": {},
+    "enterprise": {},
+    "enterprise-testnet": {}
+  }
+}

--- a/iexec-apps/demo-without-tee/iexec.json
+++ b/iexec-apps/demo-without-tee/iexec.json
@@ -1,0 +1,25 @@
+{
+  "description": "My iExec ressource description, must be at least 150 chars long in order to pass the validation checks. Describe your application, dataset or workerpool to your users",
+  "license": "MIT",
+  "author": "<wallet address>",
+  "social": {
+    "website": "?",
+    "github": "?"
+  },
+  "logo": "logo.png",
+  "buyConf": {
+    "params": {
+      "iexec_args": ""
+    },
+    "tag": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "trust": "0",
+    "callback": "0x0000000000000000000000000000000000000000"
+  },
+  "app": {
+    "owner": "<wallet address>",
+    "name": "iexec-test-app",
+    "type": "DOCKER",
+    "multiaddr": "registry.hub.docker.com/chrissc96/iexec-test-app:1.0.0",
+    "checksum": "0x222f6c98033af364699af15f9021e4dd062f48df0a9c170d3720bd9d5e3140e1"
+  }
+}

--- a/iexec-apps/demo-without-tee/run.sh
+++ b/iexec-apps/demo-without-tee/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## runs app locally, can be used for testing without iexec
+docker run --rm \
+    -v /tmp/iexec_in:/iexec_in \
+    -v /tmp/iexec_out:/iexec_out \
+    -e IEXEC_IN=/iexec_in \
+    -e IEXEC_OUT=/iexec_out \
+    iexec-test-app 400 1300
+

--- a/iexec-apps/demo-without-tee/src/app.py
+++ b/iexec-apps/demo-without-tee/src/app.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import json
+
+
+iexec_out = os.environ['IEXEC_OUT']
+rent = int(sys.argv[1])
+monthly_income = int(sys.argv[2])
+
+print("RENT: " + str(rent))
+print("MONTHLY INCOME: " + str(monthly_income))
+
+## Simple computation for deemo
+text = ""
+if monthly_income >= 3 * rent:
+    text = "Tenant makes more than three times the rent of " + str(rent)
+else:
+    text = "Tenant makes less than three times the rent of " + str(rent)
+
+print(text)
+
+## Append some results in /iexec_out/
+with open(iexec_out + '/result.txt', 'w+') as fout:
+    fout.write(text)
+
+# Declare everything is computed
+with open(iexec_out + '/computed.json', 'w+') as f:
+    json.dump({ "deterministic-output-path" : iexec_out + '/result.txt' }, f)


### PR DESCRIPTION
* Add demo application without TEE
* Input: RENT and MONTHLY_INCOME
* Is deployed to iExec Marketplace, can be run with
```bash
iexec app run 0x5e4017Bd35CbA7827e0Fa193F4B9F4f158FA254E --args "<rent> <income>" --watch --chain bellecour
```

Closes #4 